### PR TITLE
Javadocを追加

### DIFF
--- a/sourcecode/web/src/main/java/com/example/web/common/configuration/PathMatchConfig.java
+++ b/sourcecode/web/src/main/java/com/example/web/common/configuration/PathMatchConfig.java
@@ -4,6 +4,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * URLのTrailing Slashの有無を区別しないようにするための設定。
+ *
+ * <p>
+ * Spring Framework 6.0からtrailing slashのデフォルト値がfalseになった。
+ * trueへ設定することは非推奨だが、次回に対応するまでの延命措置として一時的に採用する。
+ * </p>
+ *
+ * @see <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes">
+ *      Spring Boot 3.0 Migration Guide - Spring MVC and WebFlux URL Matching Changes
+ *      </a>
+ */
 @Configuration
 public class PathMatchConfig  implements WebMvcConfigurer {
 


### PR DESCRIPTION
# 変更内容

Spring Boot 3へのアップグレード対応で新規追加された`PathMatchConfig`へJavadocを追加しました。

# 動作確認

- [x] `./mvnw checkstyle:check`でエラーが出ないことを確認
- [x] `./mvnw javadoc:javadoc`で出力したドキュメント(`target/site/apidocs/com/example/web/common/configuration/PathMatchConfig.html`)を確認
